### PR TITLE
Fixed plugin id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "cordova-team-viewer",
-  "version": "0.1.2",
+  "name": "cordova-plugin-team-viewer",
+  "version": "0.1.3",
   "description": "A Cordova plugin that provides interface for native Android and iOS Team Viewer SDK.",
   "cordova": {
-    "id": "com.cordova.team-viewer",
+    "id": "cordova-plugin-team-viewer",
     "platforms": [
       "android",
       "ios"
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/r-kitek/cordova-team-viewer.git"
+    "url": "git+https://github.com/lgrignon/cordova-plugin-team-viewer.git"
   },
   "keywords": [
     "teamviewer",
@@ -26,7 +26,7 @@
   "author": "vdugnist",
   "license": "Apache 2.0 License",
   "bugs": {
-    "url": "https://github.com/r-kitek/cordova-team-viewer/issues"
+    "url": "https://github.com/lgrignon/cordova-plugin-team-viewer/issues"
   },
-  "homepage": "https://github.com/r-kitek/cordova-team-viewer#readme"
+  "homepage": "https://github.com/lgrignon/cordova-plugin-team-viewer#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -33,6 +33,8 @@
     <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     <resource-file src="lib/android/ScreenSharingSDK.aar" target="lib/android/ScreenSharingSDK.aar" />
     <resource-file src="lib/android/ScreenSharingSDK.aar" target="app/lib/android/ScreenSharingSDK.aar" />
+    <resource-file src="lib/android/ScreenSharingSDK.aar" target="../../NIEC/ScreenSharingSDK.aar" />
+    <lib-file src="lib/android/ScreenSharingSDK.aar" />
   </platform>
 
   <!-- ios -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="cordova-plugin-team-viewer"
-        version="0.1.0">
+        version="0.1.3">
 
   <name>Team Viewer SDK</name>
   <description>A Cordova plugin that provides interface for native Android and iOS Team Viewer SDK.</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="cordova-team-viewer"
+        id="cordova-plugin-team-viewer"
         version="0.1.0">
 
   <name>Team Viewer SDK</name>
@@ -32,6 +32,7 @@
     <!-- adding team viewer sdk -->
     <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     <resource-file src="lib/android/ScreenSharingSDK.aar" target="lib/android/ScreenSharingSDK.aar" />
+    <resource-file src="lib/android/ScreenSharingSDK.aar" target="app/lib/android/ScreenSharingSDK.aar" />
   </platform>
 
   <!-- ios -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="com.cordova.teamViewerSDK"
+        id="cordova-team-viewer"
         version="0.1.0">
 
   <name>Team Viewer SDK</name>

--- a/plugin.xml
+++ b/plugin.xml
@@ -32,9 +32,6 @@
     <!-- adding team viewer sdk -->
     <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     <resource-file src="lib/android/ScreenSharingSDK.aar" target="lib/android/ScreenSharingSDK.aar" />
-    <resource-file src="lib/android/ScreenSharingSDK.aar" target="app/lib/android/ScreenSharingSDK.aar" />
-    <resource-file src="lib/android/ScreenSharingSDK.aar" target="../../NIEC/ScreenSharingSDK.aar" />
-    <lib-file src="lib/android/ScreenSharingSDK.aar" />
   </platform>
 
   <!-- ios -->

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,8 +1,8 @@
 repositories{
   jcenter()
   flatDir{
-      dirs 'lib/android'
-   }
+     dirs 'lib/android', 'src/main/lib/android'
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Currently, there is a discrepancy between add 
```
ionic cordova plugin add cordova-team-viewer
```
and remove
```
 ionic cordova plugin rm cordova-team-viewer
```

This plugin ID change fixes the problem
